### PR TITLE
fix: type err as skip open allowSyntheticDefaultImports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,22 @@
 import type { H3Event } from 'h3'
 import { eventHandler } from 'h3'
 import formidable from 'formidable'
-import type { Fields, Files } from 'formidable'
+import type { Fields, Files, Options } from 'formidable'
 
 export interface FieldsAndFiles {
   fields: Fields
   files: Files
 }
 
-export function readFiles<
-  T extends boolean | undefined = undefined,
->(event: H3Event, options?: formidable.Options & { includeFields?: T }): Promise<
+type ReadFilesReturn<T> = Promise<
   T extends undefined ? Files : T extends true ? FieldsAndFiles : Fields
-> {
+>
+
+interface ReadFilesOptions<T> extends Options {
+  includeFields?: T
+}
+
+export function readFiles<T extends boolean | undefined = undefined>(event: H3Event, options?: ReadFilesOptions<T>): ReadFilesReturn<T> {
   return new Promise<any>((resolve, reject) => {
     const form = formidable(options)
 
@@ -33,7 +37,7 @@ export function readFiles<
   })
 }
 
-export function createFileParserMiddleware<T extends boolean>(options?: formidable.Options & { includeFields?: T }) {
+export function createFileParserMiddleware<T extends boolean>(options?: ReadFilesOptions<T>) {
   return eventHandler(async (event) => {
     const files = await readFiles(event, options)
     event.context.files = files


### PR DESCRIPTION
fix #4 

'export=' is outdated, perhaps we should avoid it

It contains a little change in code style. If you don't accept it, I can withdraw this part(change of code style)


- [x] test 
- [x] lint --fix  